### PR TITLE
allow changing of window title after window creation

### DIFF
--- a/Engine/src/core/Window.cpp
+++ b/Engine/src/core/Window.cpp
@@ -88,4 +88,8 @@ namespace Engine {
 	void Window::SwapBuffers() {
 		glfwSwapBuffers(s_window);
 	}
+
+	void Window::SetTitle(const char* title) {
+		glfwSetWindowTitle(s_window, title);
+	}
 }

--- a/Engine/src/core/Window.h
+++ b/Engine/src/core/Window.h
@@ -10,6 +10,7 @@ namespace Engine {
 		static void SwapBuffers();
 		static bool ShouldClose();
 		static void Close();
+		static void SetTitle(const char* title);
 	};
 
 }

--- a/Minecraft/src/Main.cpp
+++ b/Minecraft/src/Main.cpp
@@ -19,6 +19,7 @@ void resized(const Engine::WindowResizeEvent& e) {
 
 class App : public Engine::Application {
 	void OnStart() override {
+		Engine::Window::SetTitle("Minecraft-clone");
 		Engine::EventManager::Subscribe<Engine::WindowCloseEvent>(::OnClose);
 		Engine::EventManager::Subscribe<Engine::KeyPressedEvent>(keypressed);
 		Engine::EventManager::Subscribe<Engine::WindowResizeEvent>(resized);


### PR DESCRIPTION
1. Allows to change window name after window creation
2. Changed name to "Minecraft-clone"